### PR TITLE
Fix invalid date at render release date

### DIFF
--- a/src/components/MediaMovie.js
+++ b/src/components/MediaMovie.js
@@ -52,7 +52,11 @@ const MediaMovie = ({ movie }) => {
                 {' '}
                 -
                 {' '}
-                {moment(movie.release_date).format('MM/DD/YYYY')}
+                {
+                  movie.release_date
+                    ? moment(movie.release_date).format('MM/DD/YYYY')
+                    : null
+                }
               </Text>
             </View>
           </View>

--- a/src/components/MediaTV.js
+++ b/src/components/MediaTV.js
@@ -54,7 +54,11 @@ const MediaTV = ({ tvShow }) => {
                 {' '}
                 -
                 {' '}
-                {moment(tvShow.first_air_date).format('MM/DD/YYYY')}
+                {
+                  tvShow.first_air_date
+                    ? moment(tvShow.first_air_date).format('MM/DD/YYYY')
+                    : null
+                }
               </Text>
             </View>
           </View>


### PR DESCRIPTION
This is a fix to prevent moment to display "Invalid date" when release date does not exists at search screen.